### PR TITLE
Fixes for certain autoshotgun reload sounds not playing

### DIFF
--- a/Otopack+ModsUpdates/guns/00shot.json
+++ b/Otopack+ModsUpdates/guns/00shot.json
@@ -694,11 +694,11 @@
         "volume" : 75,
         "variant" : "saiga_12",
         "files" : [
-            "guns/reload/shotgun/autoreload1.ogg",
-			"guns/reload/shotgun/autoreload2.ogg",
-			"guns/reload/shotgun/autoreload3.ogg",
-			"guns/reload/shotgun/autoreload4.ogg",
-			"guns/reload/shotgun/autoreload5.ogg"
+            "guns/reload/shotgun/autoreload_1.ogg",
+			"guns/reload/shotgun/autoreload_2.ogg",
+			"guns/reload/shotgun/autoreload_3.ogg",
+			"guns/reload/shotgun/autoreload_4.ogg",
+			"guns/reload/shotgun/autoreload_5.ogg"
         ]
     },
     {
@@ -1279,11 +1279,11 @@
         "volume" : 75,
         "variant" : "USAS_12",
         "files" : [
-            "guns/reload/shotgun/autoreload1.ogg",
-			"guns/reload/shotgun/autoreload2.ogg",
-			"guns/reload/shotgun/autoreload3.ogg",
-			"guns/reload/shotgun/autoreload4.ogg",
-			"guns/reload/shotgun/autoreload5.ogg"
+            "guns/reload/shotgun/autoreload_1.ogg",
+			"guns/reload/shotgun/autoreload_2.ogg",
+			"guns/reload/shotgun/autoreload_3.ogg",
+			"guns/reload/shotgun/autoreload_4.ogg",
+			"guns/reload/shotgun/autoreload_5.ogg"
         ]
     },
     {

--- a/Otopack+ModsUpdates/guns/410shot.json
+++ b/Otopack+ModsUpdates/guns/410shot.json
@@ -29,11 +29,11 @@
         "volume" : 75,
         "variant" : "saiga_410",
         "files" : [
-            "guns/reload/shotgun/autoreload1.ogg",
-			"guns/reload/shotgun/autoreload2.ogg",
-			"guns/reload/shotgun/autoreload3.ogg",
-			"guns/reload/shotgun/autoreload4.ogg",
-			"guns/reload/shotgun/autoreload5.ogg"
+            "guns/reload/shotgun/autoreload_1.ogg",
+			"guns/reload/shotgun/autoreload_2.ogg",
+			"guns/reload/shotgun/autoreload_3.ogg",
+			"guns/reload/shotgun/autoreload_4.ogg",
+			"guns/reload/shotgun/autoreload_5.ogg"
         ]
     },
     {


### PR DESCRIPTION
Pretty simple issue here: the Saiga, Saiga 410 and USAS-12 wouldn't play reloading sounds since they were looking for `autoreload*.ogg` when the audio files were nammed `autoreload_*.ogg`